### PR TITLE
Updating version to match new requirements

### DIFF
--- a/config/cases.jsonc
+++ b/config/cases.jsonc
@@ -199,7 +199,7 @@
   },
   {
     "name": "Gingy keychain",
-    "itemID": "619cbf9e0a7c3a1a2731940a",
+    "itemID": "62a09d3bcf4a99369e262447",
     "removeFilters": false,
     "grid": [
       {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-    "name": "ConfigurableInventories",
-    "version": "1.4.1",
+    "name": "configurable-inventories",
+    "version": "1.5.0-beta",
     "main": "src/mod.js",
     "license": "MIT",
     "author": "Harmer",
-    "akiVersion": "3.8.0",
+    "sptVersion": ">= 3.9.0",
     "loadBefore": [],
     "loadAfter": [],
     "incompatibilities": [],
-    "contributors": [],
+    "contributors": ["Super"],
     "isBundleMod": false,
     "scripts": {
         "setup": "npm i",


### PR DESCRIPTION
The version tag changed from "akiVersion" to "sptVersion", I fixed the ID of the "Gingy keychain" it was using the same ID as the "Keycard holder".

Updated the package name to be in compliance with node rules for package names.